### PR TITLE
Fix display of hidden terminal information

### DIFF
--- a/danielparks-zsh-theme.plugin.zsh
+++ b/danielparks-zsh-theme.plugin.zsh
@@ -166,9 +166,9 @@ _danielparks_theme_precmd () {
 
 	# Output invisible information for terminal title.
 	if [[ $SSH_CONNECTION ]] ; then
-		_danielparks_theme_preprompt+="\e]2;%n@%m %~\a"
+		_danielparks_theme_preprompt+=$'\e]2;%n@%m %~\a'
 	else
-		_danielparks_theme_preprompt+="\e]2;%~\a"
+		_danielparks_theme_preprompt+=$'\e]2;%~\a'
 	fi
 
 	PROMPT="${_danielparks_theme_preprompt}${_danielparks_theme_prompt}"

--- a/tests/modes/blank
+++ b/tests/modes/blank
@@ -1,6 +1,6 @@
 mkdir_cd ~/modes/blank
 unset danielparks_theme
 
-assert_prompt_eq '
+assert_prompt_eq $'
 %f%k%B%F{green}%1{✔%}%f %F{white}%~%f %F{blue}%D{%L:%M:%S %p}%f
 \e]2;%~\a%(!.%F{yellow}root.)❯%f%k%b '

--- a/tests/modes/compact
+++ b/tests/modes/compact
@@ -1,4 +1,4 @@
 mkdir_cd ~/modes/compact
 danielparks_theme=compact
 
-assert_prompt_eq '%f%k%B%F{green}%1{✔%}%f %F{white}%~%f\e]2;%~\a%(!.%F{yellow}root.)❯%f%k%b '
+assert_prompt_eq $'%f%k%B%F{green}%1{✔%}%f %F{white}%~%f\e]2;%~\a%(!.%F{yellow}root.)❯%f%k%b '

--- a/tests/modes/full
+++ b/tests/modes/full
@@ -1,6 +1,6 @@
 mkdir_cd ~/modes/full
 danielparks_theme=full
 
-assert_prompt_eq '
+assert_prompt_eq $'
 %f%k%B%F{green}%1{✔%}%f %F{white}%~%f %F{blue}%D{%L:%M:%S %p}%f
 \e]2;%~\a%(!.%F{yellow}root.)❯%f%k%b '

--- a/tests/modes/invalid
+++ b/tests/modes/invalid
@@ -1,7 +1,7 @@
 mkdir_cd ~/modes/invalid
 danielparks_theme=invalid
 
-assert_prompt_eq '
+assert_prompt_eq $'
 %B%F{red}Invalid setting for $danielparks_theme (invalid), expected one of "full", "compact", or "".%f%b
 
 %f%k%B%F{green}%1{✔%}%f %F{white}%~%f %F{blue}%D{%L:%M:%S %p}%f


### PR DESCRIPTION
In the last commmit I broke this by making it print the escaped control characters rather than the raw control characters.