### PR TITLE
Fix zsh-autosuggestions display

### DIFF
--- a/danielparks-zsh-theme.plugin.zsh
+++ b/danielparks-zsh-theme.plugin.zsh
@@ -121,13 +121,20 @@ _danielparks_theme_precmd () {
 	(( elapsed = EPOCHREALTIME - startseconds ))
 	_danielparks_theme_preexec_timestamp=
 
+	# Output invisible information for terminal title.
+	if [[ $SSH_CONNECTION ]] ; then
+		print -Pn '\e]2;%n@%m %~\a'
+	else
+		print -Pn $'\e]2;%~\a'
+	fi
+
 	# Build up string to prepend to $PROMPT (just printing it won’t work if it
 	# doesn’t end with a newline — zsh clears the line when it prints $PROMPT).
 	_danielparks_theme_preprompt=
 
 	if [[ $danielparks_theme != compact ]] ; then
 		# Blank line before prompt.
-		_danielparks_theme_preprompt=$'\n'
+		_danielparks_theme_preprompt+=$'\n'
 
 		if [[ $danielparks_theme != full && $danielparks_theme != '' ]] ; then
 			_danielparks_theme_preprompt+='%B%F{red}Invalid setting for'
@@ -162,13 +169,6 @@ _danielparks_theme_precmd () {
 		fi
 
 		_danielparks_theme_preprompt+=$'\n'
-	fi
-
-	# Output invisible information for terminal title.
-	if [[ $SSH_CONNECTION ]] ; then
-		_danielparks_theme_preprompt+=$'\e]2;%n@%m %~\a'
-	else
-		_danielparks_theme_preprompt+=$'\e]2;%~\a'
 	fi
 
 	PROMPT="${_danielparks_theme_preprompt}${_danielparks_theme_prompt}"

--- a/test-helpers.zsh
+++ b/test-helpers.zsh
@@ -17,10 +17,10 @@ after_test () {
 }
 
 assert_prompt_eq () {
-	check_arguments assert_preprompt_eq 1 "$@"
-	assert_eq "$(_danielparks_theme_precmd 2>&1)" ""
-	_danielparks_theme_precmd 2>&1 >/dev/null
-	assert_eq "$PROMPT" "$1"
+	check_arguments assert_preprompt_eq 2 "$@"
+	assert_eq "$(_danielparks_theme_precmd 2>&1)" "$(print -Pn "$1")"
+	_danielparks_theme_precmd &>/dev/null
+	assert_eq "$PROMPT" "$2"
 }
 
 assert_git_info_eq () {

--- a/tests/modes/blank
+++ b/tests/modes/blank
@@ -1,6 +1,6 @@
 mkdir_cd ~/modes/blank
 unset danielparks_theme
 
-assert_prompt_eq $'
+assert_prompt_eq $'\e]2;%~\a' $'
 %f%k%B%F{green}%1{✔%}%f %F{white}%~%f %F{blue}%D{%L:%M:%S %p}%f
-\e]2;%~\a%(!.%F{yellow}root.)❯%f%k%b '
+%(!.%F{yellow}root.)❯%f%k%b '

--- a/tests/modes/compact
+++ b/tests/modes/compact
@@ -1,4 +1,5 @@
 mkdir_cd ~/modes/compact
 danielparks_theme=compact
 
-assert_prompt_eq $'%f%k%B%F{green}%1{✔%}%f %F{white}%~%f\e]2;%~\a%(!.%F{yellow}root.)❯%f%k%b '
+assert_prompt_eq $'\e]2;%~\a' \
+	$'%f%k%B%F{green}%1{✔%}%f %F{white}%~%f%(!.%F{yellow}root.)❯%f%k%b '

--- a/tests/modes/full
+++ b/tests/modes/full
@@ -1,6 +1,6 @@
 mkdir_cd ~/modes/full
 danielparks_theme=full
 
-assert_prompt_eq $'
+assert_prompt_eq $'\e]2;%~\a' $'
 %f%k%B%F{green}%1{✔%}%f %F{white}%~%f %F{blue}%D{%L:%M:%S %p}%f
-\e]2;%~\a%(!.%F{yellow}root.)❯%f%k%b '
+%(!.%F{yellow}root.)❯%f%k%b '

--- a/tests/modes/invalid
+++ b/tests/modes/invalid
@@ -1,8 +1,8 @@
 mkdir_cd ~/modes/invalid
 danielparks_theme=invalid
 
-assert_prompt_eq $'
+assert_prompt_eq $'\e]2;%~\a' $'
 %B%F{red}Invalid setting for $danielparks_theme (invalid), expected one of "full", "compact", or "".%f%b
 
 %f%k%B%F{green}%1{✔%}%f %F{white}%~%f %F{blue}%D{%L:%M:%S %p}%f
-\e]2;%~\a%(!.%F{yellow}root.)❯%f%k%b '
+%(!.%F{yellow}root.)❯%f%k%b '


### PR DESCRIPTION
[zsh-users/zsh-autosuggestions][] had trouble with the invisible terminal instructions being part of `$PROMPT`. I printed them in the pre-command hook instead, which seems cleaner anyway.

The issue presented as the cursor being shift a few characters to the right when scrolling through autosuggestions.

Fixes #10: Broken interaction with zsh-users/zsh-autosuggestions (probably)

[zsh-users/zsh-autosuggestions]: https://github.com/zsh-users/zsh-autosuggestions